### PR TITLE
fixed error in Fis calculations

### DIFF
--- a/R/utils.basic.stats.r
+++ b/R/utils.basic.stats.r
@@ -136,7 +136,7 @@ utils.basic.stats <- function(x) {
   # Dest <- Dstp/(1 - mHs)
   Dest <- ((Htp-mHs)/(1-mHs)) * (n.pop/(n.pop-1))
   
-  Fis <- (Hs/Ho)/Hs
+  Fis <- (Hs-Ho)/Hs
   
   mFis <- 1 - (mHo/mHs)
   


### PR DESCRIPTION
@mijangos81 I'm not sure why we calculate Fis twice, once in a matrix and once in a df (Line 139 and 141), but the first one has an error (He/Ho)/He rather than (He-Ho)/He. This is a pretty serious error as Fis goes >>1