### PR TITLE
    Bug fix for cases when markers which have no scored alleles:

### DIFF
--- a/R/gl2gi.r
+++ b/R/gl2gi.r
@@ -90,10 +90,10 @@ gl2gi <- function(x,
             ind.names = x@ind.names,
             pop = x@pop,
             ploidy = 2,
-            NA.char = "-"
+            NA.char = "-",
+            loc.names = locNames(x)
         )  #, probar=probar)
     gen@other <- x@other
-    locNames(gen) <- locNames(x)
     
     # FLAG SCRIPT END
     


### PR DESCRIPTION
    ```r
    gl = platypus.gl
    class(gl) = "genlight"
    gl2gi(gl)
    ```

    Was causing error:

    Error in .nextMethod(x = x, value = value) :
      Vector length does no match number of loci