### PR TITLE
Adjust standard error for presence of NA

### DIFF
--- a/R/utils.stats.r
+++ b/R/utils.stats.r
@@ -1,4 +1,4 @@
 # Standard error
 std.error <- function(x){
-  sd(x)/sqrt(length(x))
+  sqrt(var(x, na.rm = TRUE) / sum(!is.na(x)))
   }


### PR DESCRIPTION
This change attempts to account for NA values when calculating the standard error. Currently, standard error is reported as NA for Fis in `gl.report.heterozygosity` if there are monomorphic loci included in the population, even though those loci shouldn't affect the calculation.