### PR TITLE
fix bug in gl.read.csv: gen2fbm ran unconditionally and wiped ploidy

### DIFF
--- a/R/gl.read.csv.r
+++ b/R/gl.read.csv.r
@@ -359,12 +359,15 @@ gl.read.csv <- function(filename,
     gl@other$history[[1]] <- match.call()
     
     
-    #convert to fbm 
-    if (fbm) {}
-      gl <- gl.gen2fbm(gl, verbose = verbose) 
-      if (verbose>2) {
-        cat(report(" Created an  file-backed matrix (fbm) dartR object\n"))
-      } else gl@fbm <- NULL
+    #convert to fbm
+    if (fbm) {
+      gl <- gl.gen2fbm(gl, verbose = verbose)
+      if (verbose > 2) {
+        cat(report(" Created a file-backed matrix (fbm) dartR object\n"))
+      }
+    } else {
+      gl@fbm <- NULL
+    }
     
     
     


### PR DESCRIPTION
## Summary
- Misplaced braces caused `gl.gen2fbm` to run unconditionally inside `gl.read.csv`, regardless of the `fbm` argument.
- `gl.gen2fbm` empties `@gen` (where ploidy lives), so downstream calls failed with `Fatal Error: ploidy not set in the genlight object` even though `gl.compliance.check` had just run.
- Fix: wrap the `gl.gen2fbm` call inside the `if (fbm) { ... }` block and put `gl@fbm <- NULL` in the `else` branch.

## Test plan
- [ ] `gl.read.csv(..., fbm = FALSE)` returns a genlight with ploidy populated and downstream filters (e.g. `gl.filter.locmetric(metric = "PIC")`) run without the ploidy error.
- [ ] `gl.read.csv(..., fbm = TRUE)` still produces an FBM-backed object.

Reported by Allan Male on the dartR group (subject "dartR error", 18 May 2026).