### PR TITLE
fix bug in gl.filter.overshoot: kept overshoot loci instead of removing them

### DIFF
--- a/R/gl.filter.overshoot.r
+++ b/R/gl.filter.overshoot.r
@@ -79,18 +79,19 @@ gl.filter.overshoot <- function(x,
     # Pull those loci for which the SNP position is greater than the tag length
     os <- which(snpos > nchar(trimmed))
     if(length(os)>0){
-      x2 <- x[, os]
-      # updating loc.metrics
-      x2@other$loc.metrics <- x@other$loc.metrics[os, ]
-      
       # Report the number of such loci
       if (verbose >= 3) {
         cat("  No. of loci with SNP falling outside the trimmed sequence:",
-            nLoc(x2),
+            length(os),
             "\n")
-          cat(paste0(locNames(x2), ","))
+          cat(paste0(locNames(x)[os], ","))
           cat("\n")
       }
+
+      # Delete the overshoot loci, keeping the rest
+      x2 <- x[, -os]
+      # updating loc.metrics
+      x2@other$loc.metrics <- x@other$loc.metrics[-os, ]
       
       # ADD TO HISTORY
       nh <- length(x2@other$history)


### PR DESCRIPTION
## Summary
- `gl.filter.overshoot` was inverted: it returned `x[, os]` (the overshoot loci) instead of `x[, -os]`, so it kept the loci that should be removed and discarded all the good ones.
- The `@return` doc states the recalcitrant loci should be deleted; the function did the opposite.
- Fix: report the overshoot loci from the original object (`length(os)`, `locNames(x)[os]`), then return the complement `x[, -os]` with `loc.metrics` subset to `[-os, ]`.

## Test plan
- [x] On a genlight with 4 loci and 1 known overshoot locus, the filter now returns the 3 non-overshoot loci (previously returned only the 1 overshoot locus).
- [x] `gl.report.overshoot` still reports the same overshoot count/names (unchanged).
- [x] No-overshoot path (`length(os)==0`) still returns `x` unchanged.

Reported by Jean Cordesse privately by email (subject "Issue with overshoot function - dartRverse", 2026-06-10): report said 11 overshoot loci, but the filtered object had 11 loci left instead of nLoc-11.