### PR TITLE
fix bug in gl.pcoa: NaN eigenvalues from big_SVD on FBM-backed objects

### DIFF
--- a/R/gl.pcoa.r
+++ b/R/gl.pcoa.r
@@ -777,6 +777,11 @@ gl.pcoa <- function(x,
         if (is.na(sum(as.matrix(x))))  x <- gl.impute(x, method = "neighbour", verbose = verbose)
         #run PCA on imputed data using big_SVD
          dummy <- bigstatsr::big_SVD(x@fbm, fun.scaling = big_scale(center = T, scale=FALSE), k = nInd(x)-1)
+        # big_SVD(k = nInd-1) can return NaN for the trailing rank-deficient singular
+        # value (centering leaves a null-space dimension; the internal sqrt of a
+        # tiny-negative Gram eigenvalue is NaN). Zero them so the eigenvalues stay
+        # finite and the any(eig.raw < 0) checks below are not evaluated on NA.
+         dummy$d[is.nan(dummy$d)] <- 0
         # construct glPca object
          pca <- list(scores = dummy$u %*% diag(dummy$d)/2, eig = dummy$d^2 / (4*nInd(x)),loadings=dummy$v*2)  
          class(pca) <- "glPca"


### PR DESCRIPTION
## Summary
- `gl.pcoa()` errored ("missing value where TRUE/FALSE needed") on FBM-backed genlight objects.
- The FBM branch calls `bigstatsr::big_SVD(x@fbm, k = nInd(x)-1)`; the trailing rank-deficient component (centering leaves a null-space dimension) makes big_SVD's internal `sqrt(eigenvalue)` return NaN, which flows into `pca$eig` so the `any(eig.raw < 0)` checks are evaluated on NA.
- Fix: zero the NaN singular values (`dummy$d[is.nan(dummy$d)] <- 0`) right after `big_SVD`, so eigenvalues stay finite.

## Test plan
- [x] `gl.pcoa()` on an FBM-backed genlight (508 individuals) previously crashed; now returns finite eigenvalues (eig1 = 14.957) identical to the in-memory `glPca` path, with no NaN in the scores.
- [x] In-memory `gl.pcoa()` path unchanged.

Found while building an FBM-based PCA workflow (`gl.gen2fbm` -> `gl.impute` -> `gl.pcoa`). Only triggers when a trailing eigenvalue goes slightly negative, which is size-dependent: `platypus.gl` (k=80) escapes, a 508-individual set (k=507) hits it.