### PR TITLE
gl.test.heterozygosity: bug fixes, bootstrap-engine refactor and docs (bundles gl.tree.fitch cross-platform fix)

### DIFF
--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -347,6 +347,7 @@ gl.test.heterozygosity <- function(x,
                                 linewidth = 1
                             ) + scale_color_manual(
                                 name = "Values",
+                                breaks = c("alpha1", "alpha2", "Observed", "Zero_value"),
                                 values = c(
                                     Zero_value = "blue",
                                     Observed = "green",
@@ -356,8 +357,8 @@ gl.test.heterozygosity <- function(x,
                                 labels = c(
                                     paste("Sig. ", alpha1),
                                     paste("Sig. ", alpha2),
-                                    "Zero value",
-                                    "Observed"
+                                    "Observed",
+                                    "Zero value"
                                 )
                             ) + guides(color = guide_legend(
                                 override.aes = list(size = 5),

--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -205,7 +205,8 @@ gl.test.heterozygosity <- function(x,
         total_number_plots <- choose(nPop(x), 2)
         # create list to contain plots
         p_list <- list()
-        
+    }
+
         for (y in 1:(nPop(x) - 1)) {
             for (z in (y + 1):nPop(x)) {
                 count <- count + 1
@@ -226,6 +227,7 @@ gl.test.heterozygosity <- function(x,
                     as.numeric(quantile(mat[y, z,], lower2))
                 
                 # Is zero within the range specified by the upper and lower limits
+                signif_res <- NA_character_
                 if (0 < u2quantile && 0 > l2quantile) {
                     signif_res <- paste0("non-sig @", lower2)
                 }
@@ -251,8 +253,9 @@ gl.test.heterozygosity <- function(x,
                 df$diff[count] <- obs
                 df$significance[count] <- signif_res
                 df$pval[count] <- p
-                
-                # Plot the histogram of pairwise differences
+
+                # Plot the histogram of pairwise differences (only when plot.out = TRUE)
+                if (plot.out) {
                 
                 # Construct the label
                 title <-
@@ -368,11 +371,13 @@ gl.test.heterozygosity <- function(x,
                     
                     p_list[[count]] <- suppressWarnings(p_temp)
                 }
-                
+                }
+
             }
             
         }
         
+    if (plot.out) {
         # PRINTING OUTPUTS
         match_call <-
             paste0(names(match.call()),
@@ -392,7 +397,7 @@ gl.test.heterozygosity <- function(x,
             # SAVE INTERMEDIATES TO TEMPDIR
             temp_plot <- paste0(plot.file,"_", seq_1[i], "_to_", seq_2[i])
             if(!is.null(plot.file)){
-              tmp <- utils.plot.save(df,
+              tmp <- utils.plot.save(p_final,
                                      dir=plot.dir,
                                      file=temp_plot,
                                      verbose=verbose)

--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -2,19 +2,29 @@
 #' @title Tests the difference in heterozygosity between populations taken
 #'  pairwise
 #' @description
-#' Calculates the expected heterozygosities for each population in a genlight
-#' object, and uses re-randomization to test the statistical significance of
-#' differences in heterozygosity between populations taken pairwise.
+#' Calculates the unbiased expected heterozygosity (uHe) for each population in
+#' a genlight object and uses bootstrapping to test the statistical significance
+#' of differences in heterozygosity between populations taken pairwise. Each
+#' population's heterozygosity is bootstrapped by resampling either individuals
+#' (boot.method = "ind", the default) or loci (boot.method = "loc") with the
+#' shared engine also used by gl.report.heterozygosity, and each pairwise
+#' difference is summarised with a bootstrap confidence interval and a two-sided
+#' p value (Benjamini-Hochberg adjusted across pairs).
 #' 
 #' Expected heterozygosity is calculated using the correction for sample size 
 #' following equation 2 from Nei 1978. 
 #' 
 #' @param x A genlight object containing the SNP genotypes [required].
-#' @param nreps Number of replications of the re-randomization [default 1,000].
+#' @param nreps Number of bootstrap replicates used to build the sampling
+#' distribution of each pairwise difference [default 1,000].
+#' @param boot.method Resample across individuals ("ind") or across loci ("loc")
+#' when bootstrapping the heterozygosity of each population [default "ind"].
 #' @param alpha1 First significance level for comparison with diff=0 on plot
 #' [default 0.05].
 #' @param alpha2 Second significance level for comparison with diff=0 on plot
 #' [default 0.01].
+#' @param conf Confidence level for the bootstrap confidence interval of each
+#' pairwise difference [default 0.95].
 #' @param plot.out If TRUE, plots a sampling distribution of the differences for
 #' each comparison [default TRUE].
 #' @param max_plots Maximum number of plots to print per page [default 6].
@@ -47,8 +57,11 @@
 #'  \item \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} and \item
 #'  \url{https://yutannihilation.github.io/allYourFigureAreBelongToUs/ggthemes/}
 #'  }
-#' @return A dataframe containing population labels, heterozygosities and sample
-#'  sizes
+#' @return A dataframe with one row per population pair containing the two
+#'  population labels, the observed difference in unbiased expected
+#'  heterozygosity (pop1 - pop2), the lower and upper bounds of its bootstrap
+#'  confidence interval, the significance label and the two-sided bootstrap
+#'  p value (raw and Benjamini-Hochberg adjusted).
 #' @author Custodian: Luis Mijangos (Post to
 #'  \url{https://groups.google.com/d/forum/dartr})
 #' @references 
@@ -57,15 +70,17 @@
 #' 
 #' @examples
 #' if (isTRUE(getOption("dartR_fbm"))) platypus.gl <- gl.gen2fbm(platypus.gl)
-#' out <- gl.test.heterozygosity(platypus.gl, nreps=1, verbose=3, plot.out=TRUE)
+#' out <- gl.test.heterozygosity(platypus.gl, nreps=100, verbose=3, plot.out=TRUE)
 #' @family Genetic variation within populations
 #' @import patchwork
 #' @export
 
 gl.test.heterozygosity <- function(x,
-                                   nreps = 100,
+                                   nreps = 1000,
+                                   boot.method = "ind",
                                    alpha1 = 0.05,
                                    alpha2 = 0.01,
+                                   conf = 0.95,
                                    plot.out = TRUE,
                                    max_plots = 6,
                                    plot.theme = theme_dartR(),
@@ -104,6 +119,14 @@ gl.test.heterozygosity <- function(x,
             "Warning: Second alpha value should be between 0 and 1, set to 0.01\n"
         ))
         alpha2 <- 0.01
+    }
+
+    # Bootstrap resampling unit
+    if (!(boot.method == "ind" || boot.method == "loc")) {
+        cat(warn(
+            "  Warning: boot.method must be 'ind' or 'loc', set to 'ind'\n"
+        ))
+        boot.method <- "ind"
     }
     
     upper1 <- 1 - alpha1  # significance level #1
@@ -155,35 +178,75 @@ gl.test.heterozygosity <- function(x,
     
     # DO THE JOB
     
-    # Calculate a matrix of heterozygosities (He)
-    out <- utils.het.pop(x)
-    D <- outer(out, out, "-")
-    
-    # Simulate the distribution of differences in He by population, pairwise Initialize the data matrix to hold simulation results
+    # Bootstrap the unbiased expected heterozygosity (uHe) of each population
+    # with the shared engine (pop.het + boot::boot, as used by
+    # gl.report.heterozygosity), so this function resamples the same way. The
+    # unit of resampling is set by boot.method: individuals ("ind", the default,
+    # which captures the finite- and unequal-sample-size uncertainty) or loci
+    # ("loc").
     if (verbose >= 2) {
-        cat(
-            report(
-                "  Calculating the sampling distributions for pairwise differences between populations by re-randomization\n"
+        cat(report(
+            paste0(
+                "  Bootstrapping the heterozygosity of each population ",
+                "(boot.method = '", boot.method,
+                "') to build the pairwise difference distributions\n"
             )
-        )
+        ))
         cat(important("  Please be patient .... go have a coffee\n"))
     }
-    mat <- array(data = NA, dim = c(nPop(x), nPop(x), nreps))
-    n <- nLoc(x)
-    for (i in 1:nreps) {
-        # Sample the dataset
-        x2 <- x[, sample(1:n, n, replace = T)]
-        # Calculate Heterozygosity
-        out <- utils.het.pop(x2)
-        # Save difference values away
-        mat[, , i] <- outer(out, out, "-")
+
+    sgl <- seppop(x)
+    npop <- nPop(x)
+
+    # he_boot: nreps bootstrap replicates of uHe for each population (rows = pops)
+    he_boot <- matrix(NA_real_, nrow = npop, ncol = nreps)
+    out <- numeric(npop)                 # observed uHe per population
+    for (i in seq_len(npop)) {
+        pop_mat <- as.matrix(sgl[[i]])
+        if (boot.method == "loc") {
+            pop_mat <- t(pop_mat)
+        }
+        # withCallingHandlers muffles only the benign recycling warning coming
+        # from the unused adjusted-Ho term inside pop.het (Ho.loc has length
+        # nLoc while its n_loc has length nInd); the uHe we extract is unaffected.
+        res_boots <- withCallingHandlers(
+            boot::boot(
+                data = pop_mat,
+                statistic = pop.het,
+                n.invariant = 0,
+                aHet = FALSE,
+                boot_method = boot.method,
+                R = nreps
+            ),
+            warning = function(w) {
+                if (grepl("longer object length", conditionMessage(w))) {
+                    invokeRestart("muffleWarning")
+                }
+            }
+        )
+        # pop.het returns c(Ho, He, uHe, FIS); uHe is column 3
+        out[i] <- res_boots$t0[3]
+        he_boot[i, ] <- res_boots$t[, 3]
+    }
+    names(out) <- popNames(x)
+
+    # Observed pairwise differences (pop1 - pop2) and their bootstrap
+    # distributions. mat[y, z, ] holds the resampled difference uHe(y) - uHe(z);
+    # individuals (or loci) in different populations are independent samples, so
+    # the per-population bootstraps are paired replicate-wise to form it.
+    D <- outer(out, out, "-")
+    mat <- array(data = NA_real_, dim = c(npop, npop, nreps))
+    for (y in seq_len(npop)) {
+        for (z in seq_len(npop)) {
+            mat[y, z, ] <- he_boot[y, ] - he_boot[z, ]
+        }
     }
     
     # Calculate the p values, significance for pairwise differences Dataframe to store output
     df <-
-        data.frame(matrix(ncol = 5, nrow = (nPop(x) * nPop(x) - nPop(x)) / 2))
+        data.frame(matrix(ncol = 7, nrow = (nPop(x) * nPop(x) - nPop(x)) / 2))
     colnames(df) <-
-        c("pop1", "pop2", "diff", "significance", "pval")
+        c("pop1", "pop2", "diff", "CIlower", "CIupper", "significance", "pval")
     
     count <- 0
     
@@ -200,7 +263,7 @@ gl.test.heterozygosity <- function(x,
         }
         
         # set the limit values for the x axis in the plots
-        x_axis_limits_lots <- c(min(mat), max(mat))
+        x_axis_limits_lots <- c(min(mat, na.rm = TRUE), max(mat, na.rm = TRUE))
         # count how many plots are going to be created
         total_number_plots <- choose(nPop(x), 2)
         # create list to contain plots
@@ -241,16 +304,25 @@ gl.test.heterozygosity <- function(x,
                     signif_res <- paste0("sig @", lower2)
                 }
                 
-                # p value for zero
+                # Two-sided bootstrap p value that the difference is zero, using
+                # the (1 + b) / (nreps + 1) convention so p is never exactly 0.
                 values <- mat[y, z,]
-                p <-
-                    min(length(values[values > 0]), length(values[values <= 0])) / length(abs(values))
-                p <- signif(p, digits = 6)
-                
+                nb <- length(values)
+                p <- 2 * min((1 + sum(values <= 0)) / (nb + 1),
+                             (1 + sum(values >= 0)) / (nb + 1))
+                p <- signif(min(p, 1), digits = 6)
+
+                # Percentile bootstrap confidence interval for the difference
+                ci <- as.numeric(quantile(values,
+                                          c((1 - conf) / 2, 1 - (1 - conf) / 2),
+                                          na.rm = TRUE))
+
                 # Store results in a df
                 df$pop1[count] <- popNames(x)[y]
                 df$pop2[count] <- popNames(x)[z]
                 df$diff[count] <- obs
+                df$CIlower[count] <- signif(ci[1], 6)
+                df$CIupper[count] <- signif(ci[2], 6)
                 df$significance[count] <- signif_res
                 df$pval[count] <- p
 
@@ -412,8 +484,11 @@ gl.test.heterozygosity <- function(x,
         
     
     
+    # Multiple-testing correction across the pairwise comparisons
+    df$pval.adj <- signif(p.adjust(df$pval, method = "BH"), 6)
+
     print(df)
-    
+
     # Optionally save the plot ---------------------
     
     if(!is.null(plot.file)){

--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -2,17 +2,13 @@
 #' @title Tests the difference in heterozygosity between populations taken
 #'  pairwise
 #' @description
-#' Calculates the unbiased expected heterozygosity (uHe) for each population in
-#' a genlight object and uses bootstrapping to test the statistical significance
-#' of differences in heterozygosity between populations taken pairwise. Each
-#' population's heterozygosity is bootstrapped by resampling either individuals
-#' (boot.method = "ind", the default) or loci (boot.method = "loc") with the
-#' shared engine also used by gl.report.heterozygosity, and each pairwise
-#' difference is summarised with a bootstrap confidence interval and a two-sided
-#' p value (Benjamini-Hochberg adjusted across pairs).
-#' 
-#' Expected heterozygosity is calculated using the correction for sample size 
-#' following equation 2 from Nei 1978. 
+#' Tests whether the unbiased expected heterozygosity (uHe) differs between
+#' populations, for every pair of populations in a genlight object. The uHe of
+#' each population is bootstrapped (resampling individuals or loci, see Details),
+#' and for each pair the function returns the observed difference (pop1 - pop2),
+#' a bootstrap confidence interval, a significance label and a two-sided p value
+#' (raw and Benjamini-Hochberg adjusted across pairs). uHe is corrected for
+#' sample size following equation 2 of Nei (1978).
 #' 
 #' @param x A genlight object containing the SNP genotypes [required].
 #' @param nreps Number of bootstrap replicates used to build the sampling
@@ -39,24 +35,54 @@
 #' progress log; 3, progress and results summary; 5, full report
 #' [default NULL, unless specified using gl.set.verbosity].
 #' @details
-#'\strong{ Function's output }
-
-#' If plot.out = TRUE, plots are created showing the sampling distribution for
-#' the difference between each pair of heterozygosities, marked with the
-#' critical limits alpha1 and alpha2, the observed heterozygosity, and the zero
-#' value (if in range).
-
-#'   If a plot.file is given, the ggplot arising from this function is saved as an "RDS" 
-#' binary file using saveRDS(); can be reloaded with readRDS(). A file name must be 
-#' specified for the plot to be saved.
-
-#'  If a plot directory (plot.dir) is specified, the ggplot binary is saved to that
-#'  directory; otherwise to the tempdir(). 
-
-#'  Examples of other themes that can be used can be consulted in \itemize{
-#'  \item \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} and \item
-#'  \url{https://yutannihilation.github.io/allYourFigureAreBelongToUs/ggthemes/}
+#' \strong{Choosing the resampling unit (boot.method)}
+#'
+#' The uHe of each population is bootstrapped with the same engine as
+#' \code{\link{gl.report.heterozygosity}}, and \code{boot.method} sets what is
+#' resampled:
+#' \itemize{
+#'  \item \code{"ind"} (default) resamples individuals, and so captures the
+#'  uncertainty from having genotyped a finite, and often unequal, number of
+#'  individuals per population. Use it to ask whether the two samples come from
+#'  populations that differ in heterozygosity, which is the usual question.
+#'  \item \code{"loc"} resamples loci, and so captures the uncertainty from the
+#'  loci being a finite sample of the genome, with the individuals held fixed.
+#'  Use it when the sampled individuals are effectively the whole population and
+#'  the loci are the main source of sampling noise.
 #'  }
+#' The two units answer different questions and can yield different confidence
+#' intervals and p values for the same data. When in doubt use "ind": for most
+#' DArT datasets the number of individuals per population is small and dominates
+#' the uncertainty. For "loc" the loci are resampled independently within each
+#' population, so the interval is slightly conservative.
+#'
+#' \strong{Interpreting the plot}
+#'
+#' With \code{plot.out = TRUE} one histogram is drawn per pair of populations.
+#' The histogram is the bootstrap distribution of the difference in uHe
+#' (pop1 - pop2), with four vertical lines:
+#' \itemize{
+#'  \item green: the observed difference.
+#'  \item blue: zero (no difference).
+#'  \item two dark red lines: the significance limits at level \code{alpha1}
+#'  (default 0.05).
+#'  \item two bright red lines: the limits at level \code{alpha2} (default 0.01).
+#'  }
+#' Read significance from the blue zero line, not the green one. If zero lies
+#' outside the red lines of a given level, the difference is significant at that
+#' level; if it lies inside the \code{alpha1} lines, the difference is not
+#' significant. The green observed line sits near the centre of its own bootstrap
+#' distribution by construction, so its position is not the test. Each panel
+#' subtitle gives the significance label and the p value.
+#'
+#' \strong{Saving the plot}
+#'
+#' If \code{plot.file} is given, the ggplot is saved as an RDS file with
+#' \code{saveRDS()} and can be reloaded with \code{readRDS()}. It is written to
+#' \code{plot.dir} if given, otherwise to \code{tempdir()}. Other ggplot themes
+#' can be consulted at
+#' \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} and
+#' \url{https://yutannihilation.github.io/allYourFigureAreBelongToUs/ggthemes/}.
 #' @return A dataframe with one row per population pair containing the two
 #'  population labels, the observed difference in unbiased expected
 #'  heterozygosity (pop1 - pop2), the lower and upper bounds of its bootstrap

--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -39,22 +39,23 @@
 #'
 #' The uHe of each population is bootstrapped with the same engine as
 #' \code{\link{gl.report.heterozygosity}}, and \code{boot.method} sets what is
-#' resampled:
+#' resampled. The two units answer different questions and can yield different
+#' confidence intervals and p values for the same data:
 #' \itemize{
-#'  \item \code{"ind"} (default) resamples individuals, and so captures the
-#'  uncertainty from having genotyped a finite, and often unequal, number of
-#'  individuals per population. Use it to ask whether the two samples come from
-#'  populations that differ in heterozygosity, which is the usual question.
-#'  \item \code{"loc"} resamples loci, and so captures the uncertainty from the
-#'  loci being a finite sample of the genome, with the individuals held fixed.
-#'  Use it when the sampled individuals are effectively the whole population and
-#'  the loci are the main source of sampling noise.
+#'  \item \code{"ind"} (default) resamples individuals. It treats the sampled
+#'  individuals as a sample of each population and tests whether the two
+#'  populations differ in heterozygosity. This is the usual question.
+#'  \item \code{"loc"} resamples loci, with the individuals held fixed. It tests
+#'  whether the genome-wide difference is consistent across loci rather than
+#'  driven by a few of them, and does not generalise to the populations the
+#'  individuals came from. Use it only when the individuals are effectively a
+#'  census of each group (for example a fully sampled captive lineage or a
+#'  complete cohort), where there is no individual-sampling variance to account
+#'  for; with a sample of individuals from each population, use \code{"ind"}.
 #'  }
-#' The two units answer different questions and can yield different confidence
-#' intervals and p values for the same data. When in doubt use "ind": for most
-#' DArT datasets the number of individuals per population is small and dominates
-#' the uncertainty. For "loc" the loci are resampled independently within each
-#' population, so the interval is slightly conservative.
+#' For \code{"loc"} the loci are resampled independently within each population
+#' and treated as independent, so the interval ignores linkage and is
+#' approximate.
 #'
 #' \strong{Interpreting the plot}
 #'

--- a/R/gl.tree.fitch.r
+++ b/R/gl.tree.fitch.r
@@ -247,10 +247,10 @@ gl.tree.fitch <- function(D,
   hold <- getwd()
   setwd(tempdir())
   if(file.exists(file.path(tempdir(),"outfile"))){
-    shell(paste("del outfile"))
+    unlink("outfile")
   }
   if(file.exists(file.path(tempdir(),"outtree"))){
-    shell(paste("del outtree"))
+    unlink("outtree")
   }
   setwd(hold)
   
@@ -282,7 +282,7 @@ gl.tree.fitch <- function(D,
   if(verbose >= 2){cat(report("  Running fitch from the Phylip executables\n"))}
   hold <- getwd()
   setwd(tempdir())
-     shell(cmd.fm)
+     system(cmd.fm)
   setwd(hold)
   # This will produce an output file called outfile, and a newick file called outtree
   
@@ -354,7 +354,7 @@ gl.tree.fitch <- function(D,
     setwd(tempdir())
     if(file.exists(file.path(tempdir(),"outtree"))){
       cat("    Deleting old outtree file\n")
-      shell(paste("del outtree"))
+      unlink("outtree")
     }
     
     # Create the command file for fitch
@@ -385,11 +385,11 @@ gl.tree.fitch <- function(D,
     
     # Execute the command file by passing it to fitch
     
-    shell(cmd.fm)
+    system(cmd.fm)
     
     # Copy the outtree file from fitch to the intree for consense
-    shell(paste("cp outtree intree"))
-    shell(paste("del outtree"))
+    file.copy("outtree", "intree", overwrite = TRUE)
+    unlink("outtree")
     
     # Create the consensus command file
     vector <- rep(NA,4)
@@ -409,7 +409,7 @@ gl.tree.fitch <- function(D,
     # Execute the command file by passing it to consense
     # hold <- getwd()
     #  setwd(tempdir())
-    shell(cmd.cns)
+    system(cmd.cns)
     #setwd(hold)
     # This will append to an output file called outfile, and output a newick file called outtree
     

--- a/man/gl.test.heterozygosity.Rd
+++ b/man/gl.test.heterozygosity.Rd
@@ -80,22 +80,23 @@ sample size following equation 2 of Nei (1978).
 
 The uHe of each population is bootstrapped with the same engine as
 \code{\link{gl.report.heterozygosity}}, and \code{boot.method} sets what is
-resampled:
+resampled. The two units answer different questions and can yield different
+confidence intervals and p values for the same data:
 \itemize{
- \item \code{"ind"} (default) resamples individuals, and so captures the
- uncertainty from having genotyped a finite, and often unequal, number of
- individuals per population. Use it to ask whether the two samples come from
- populations that differ in heterozygosity, which is the usual question.
- \item \code{"loc"} resamples loci, and so captures the uncertainty from the
- loci being a finite sample of the genome, with the individuals held fixed.
- Use it when the sampled individuals are effectively the whole population and
- the loci are the main source of sampling noise.
+ \item \code{"ind"} (default) resamples individuals. It treats the sampled
+ individuals as a sample of each population and tests whether the two
+ populations differ in heterozygosity. This is the usual question.
+ \item \code{"loc"} resamples loci, with the individuals held fixed. It tests
+ whether the genome-wide difference is consistent across loci rather than
+ driven by a few of them, and does not generalise to the populations the
+ individuals came from. Use it only when the individuals are effectively a
+ census of each group (for example a fully sampled captive lineage or a
+ complete cohort), where there is no individual-sampling variance to account
+ for; with a sample of individuals from each population, use \code{"ind"}.
  }
-The two units answer different questions and can yield different confidence
-intervals and p values for the same data. When in doubt use "ind": for most
-DArT datasets the number of individuals per population is small and dominates
-the uncertainty. For "loc" the loci are resampled independently within each
-population, so the interval is slightly conservative.
+For \code{"loc"} the loci are resampled independently within each population
+and treated as independent, so the interval ignores linkage and is
+approximate.
 
 \strong{Interpreting the plot}
 

--- a/man/gl.test.heterozygosity.Rd
+++ b/man/gl.test.heterozygosity.Rd
@@ -7,9 +7,11 @@
 \usage{
 gl.test.heterozygosity(
   x,
-  nreps = 100,
+  nreps = 1000,
+  boot.method = "ind",
   alpha1 = 0.05,
   alpha2 = 0.01,
+  conf = 0.95,
   plot.out = TRUE,
   max_plots = 6,
   plot.theme = theme_dartR(),
@@ -22,13 +24,20 @@ gl.test.heterozygosity(
 \arguments{
 \item{x}{A genlight object containing the SNP genotypes [required].}
 
-\item{nreps}{Number of replications of the re-randomization [default 1,000].}
+\item{nreps}{Number of bootstrap replicates used to build the sampling
+distribution of each pairwise difference [default 1,000].}
+
+\item{boot.method}{Resample across individuals ("ind") or across loci ("loc")
+when bootstrapping the heterozygosity of each population [default "ind"].}
 
 \item{alpha1}{First significance level for comparison with diff=0 on plot
 [default 0.05].}
 
 \item{alpha2}{Second significance level for comparison with diff=0 on plot
 [default 0.01].}
+
+\item{conf}{Confidence level for the bootstrap confidence interval of each
+pairwise difference [default 0.95].}
 
 \item{plot.out}{If TRUE, plots a sampling distribution of the differences for
 each comparison [default TRUE].}
@@ -51,13 +60,21 @@ progress log; 3, progress and results summary; 5, full report
 [default NULL, unless specified using gl.set.verbosity].}
 }
 \value{
-A dataframe containing population labels, heterozygosities and sample
- sizes
+A dataframe with one row per population pair containing the two
+ population labels, the observed difference in unbiased expected
+ heterozygosity (pop1 - pop2), the lower and upper bounds of its bootstrap
+ confidence interval, the significance label and the two-sided bootstrap
+ p value (raw and Benjamini-Hochberg adjusted).
 }
 \description{
-Calculates the expected heterozygosities for each population in a genlight
-object, and uses re-randomization to test the statistical significance of
-differences in heterozygosity between populations taken pairwise.
+Calculates the unbiased expected heterozygosity (uHe) for each population in
+a genlight object and uses bootstrapping to test the statistical significance
+of differences in heterozygosity between populations taken pairwise. Each
+population's heterozygosity is bootstrapped by resampling either individuals
+(boot.method = "ind", the default) or loci (boot.method = "loc") with the
+shared engine also used by gl.report.heterozygosity, and each pairwise
+difference is summarised with a bootstrap confidence interval and a two-sided
+p value (Benjamini-Hochberg adjusted across pairs).
 
 Expected heterozygosity is calculated using the correction for sample size 
 following equation 2 from Nei 1978.
@@ -80,7 +97,7 @@ specified for the plot to be saved.
 }
 \examples{
 if (isTRUE(getOption("dartR_fbm"))) platypus.gl <- gl.gen2fbm(platypus.gl)
-out <- gl.test.heterozygosity(platypus.gl, nreps=1, verbose=3, plot.out=TRUE)
+out <- gl.test.heterozygosity(platypus.gl, nreps=100, verbose=3, plot.out=TRUE)
 }
 \references{
 Nei, M. (1978). Estimation of average heterozygosity and genetic distance 

--- a/man/gl.test.heterozygosity.Rd
+++ b/man/gl.test.heterozygosity.Rd
@@ -67,33 +67,63 @@ A dataframe with one row per population pair containing the two
  p value (raw and Benjamini-Hochberg adjusted).
 }
 \description{
-Calculates the unbiased expected heterozygosity (uHe) for each population in
-a genlight object and uses bootstrapping to test the statistical significance
-of differences in heterozygosity between populations taken pairwise. Each
-population's heterozygosity is bootstrapped by resampling either individuals
-(boot.method = "ind", the default) or loci (boot.method = "loc") with the
-shared engine also used by gl.report.heterozygosity, and each pairwise
-difference is summarised with a bootstrap confidence interval and a two-sided
-p value (Benjamini-Hochberg adjusted across pairs).
-
-Expected heterozygosity is calculated using the correction for sample size 
-following equation 2 from Nei 1978.
+Tests whether the unbiased expected heterozygosity (uHe) differs between
+populations, for every pair of populations in a genlight object. The uHe of
+each population is bootstrapped (resampling individuals or loci, see Details),
+and for each pair the function returns the observed difference (pop1 - pop2),
+a bootstrap confidence interval, a significance label and a two-sided p value
+(raw and Benjamini-Hochberg adjusted across pairs). uHe is corrected for
+sample size following equation 2 of Nei (1978).
 }
 \details{
-\strong{ Function's output }
-If plot.out = TRUE, plots are created showing the sampling distribution for
-the difference between each pair of heterozygosities, marked with the
-critical limits alpha1 and alpha2, the observed heterozygosity, and the zero
-value (if in range).
-  If a plot.file is given, the ggplot arising from this function is saved as an "RDS" 
-binary file using saveRDS(); can be reloaded with readRDS(). A file name must be 
-specified for the plot to be saved.
- If a plot directory (plot.dir) is specified, the ggplot binary is saved to that
- directory; otherwise to the tempdir(). 
- Examples of other themes that can be used can be consulted in \itemize{
- \item \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} and \item
- \url{https://yutannihilation.github.io/allYourFigureAreBelongToUs/ggthemes/}
+\strong{Choosing the resampling unit (boot.method)}
+
+The uHe of each population is bootstrapped with the same engine as
+\code{\link{gl.report.heterozygosity}}, and \code{boot.method} sets what is
+resampled:
+\itemize{
+ \item \code{"ind"} (default) resamples individuals, and so captures the
+ uncertainty from having genotyped a finite, and often unequal, number of
+ individuals per population. Use it to ask whether the two samples come from
+ populations that differ in heterozygosity, which is the usual question.
+ \item \code{"loc"} resamples loci, and so captures the uncertainty from the
+ loci being a finite sample of the genome, with the individuals held fixed.
+ Use it when the sampled individuals are effectively the whole population and
+ the loci are the main source of sampling noise.
  }
+The two units answer different questions and can yield different confidence
+intervals and p values for the same data. When in doubt use "ind": for most
+DArT datasets the number of individuals per population is small and dominates
+the uncertainty. For "loc" the loci are resampled independently within each
+population, so the interval is slightly conservative.
+
+\strong{Interpreting the plot}
+
+With \code{plot.out = TRUE} one histogram is drawn per pair of populations.
+The histogram is the bootstrap distribution of the difference in uHe
+(pop1 - pop2), with four vertical lines:
+\itemize{
+ \item green: the observed difference.
+ \item blue: zero (no difference).
+ \item two dark red lines: the significance limits at level \code{alpha1}
+ (default 0.05).
+ \item two bright red lines: the limits at level \code{alpha2} (default 0.01).
+ }
+Read significance from the blue zero line, not the green one. If zero lies
+outside the red lines of a given level, the difference is significant at that
+level; if it lies inside the \code{alpha1} lines, the difference is not
+significant. The green observed line sits near the centre of its own bootstrap
+distribution by construction, so its position is not the test. Each panel
+subtitle gives the significance label and the p value.
+
+\strong{Saving the plot}
+
+If \code{plot.file} is given, the ggplot is saved as an RDS file with
+\code{saveRDS()} and can be reloaded with \code{readRDS()}. It is written to
+\code{plot.dir} if given, otherwise to \code{tempdir()}. Other ggplot themes
+can be consulted at
+\url{https://ggplot2.tidyverse.org/reference/ggtheme.html} and
+\url{https://yutannihilation.github.io/allYourFigureAreBelongToUs/ggthemes/}.
 }
 \examples{
 if (isTRUE(getOption("dartR_fbm"))) platypus.gl <- gl.gen2fbm(platypus.gl)


### PR DESCRIPTION
## gl.test.heterozygosity

Four commits reworking this function, prompted by a user on the dartR google group who was confused by the plot.

**Bug fixes**
- Results (`diff`/`significance`/`pval`) were computed only inside `if (plot.out)`, so `plot.out = FALSE` returned an all-`NA` table. Moved the computation out of the plotting guard.
- The intermediate RDS save wrote the data frame instead of the assembled ggplot, contradicting the documented behaviour; now saves the plot (the table is still saved separately as `table_<plot.file>`).
- Legend labels for "Observed" and "Zero value" were swapped (ggplot's implicit, locale-dependent alphabetical break order combined with an unnamed `labels` vector). Pinned with an explicit `breaks`.

**Refactor onto the shared bootstrap engine**
- Replaced the hardcoded locus re-randomization with the same `pop.het` + `boot::boot` engine used by `gl.report.heterozygosity`, exposing `boot.method = c("ind","loc")` with `"ind"` (resample individuals) as the default. The individual axis captures the finite/unequal-sample-size uncertainty the old locus-only bootstrap ignored.
- Proper two-sided bootstrap p using the `(1 + b)/(nreps + 1)` convention (never exactly 0); percentile CI per pair (`conf`, default 0.95); Benjamini-Hochberg `pval.adj` across pairs; `nreps` default raised 100 -> 1000; new params `boot.method`, `conf`.

**Docs**
- Rewrote the description and details: what the function does, how to choose `boot.method` (ind vs loc), and how to read the plot (significance is read from the zero line, not the observed line).

Note: `pop.het` (in `utils.het.report.r`) has a latent vector-recycling bug in its adjusted-Ho term that also affects `gl.report.heterozygosity`'s adjusted bootstrap. It is left out of this PR; the benign warning is muffled at the call site.

## gl.tree.fitch (pre-existing on this branch)
- Replaced the Windows-only `shell()` with cross-platform `system()` / `unlink()` / `file.copy()` so the function runs on macOS/Linux.

## Test plan
- [x] gl.test.heterozygosity: `boot.method` "ind"/"loc", `plot.out` TRUE/FALSE and the bad-`boot.method` fallback verified on `platypus.gl`; p never 0; CI brackets the observed difference; man page regenerated and renders.
- [x] gl.tree.fitch builds a Fitch-Margoliash tree on macOS end-to-end.
- [ ] Windows path for gl.tree.fitch.
