### PR TITLE
fix bug in pop.het: per-individual n_loc corrupted adjusted heterozygosity

### DIFF
--- a/R/gl.test.heterozygosity.r
+++ b/R/gl.test.heterozygosity.r
@@ -233,23 +233,13 @@ gl.test.heterozygosity <- function(x,
         if (boot.method == "loc") {
             pop_mat <- t(pop_mat)
         }
-        # withCallingHandlers muffles only the benign recycling warning coming
-        # from the unused adjusted-Ho term inside pop.het (Ho.loc has length
-        # nLoc while its n_loc has length nInd); the uHe we extract is unaffected.
-        res_boots <- withCallingHandlers(
-            boot::boot(
-                data = pop_mat,
-                statistic = pop.het,
-                n.invariant = 0,
-                aHet = FALSE,
-                boot_method = boot.method,
-                R = nreps
-            ),
-            warning = function(w) {
-                if (grepl("longer object length", conditionMessage(w))) {
-                    invokeRestart("muffleWarning")
-                }
-            }
+        res_boots <- boot::boot(
+            data = pop_mat,
+            statistic = pop.het,
+            n.invariant = 0,
+            aHet = FALSE,
+            boot_method = boot.method,
+            R = nreps
         )
         # pop.het returns c(Ho, He, uHe, FIS); uHe is column 3
         out[i] <- res_boots$t0[3]

--- a/R/utils.het.report.r
+++ b/R/utils.het.report.r
@@ -10,9 +10,10 @@ pop.het <- function(df,
                           aHet) {
 
     Ho.loc <- colMeans(df == 1, na.rm = TRUE)
-    n_loc <- apply(df, 1, function(y) {
-      sum(!is.na(y))
-    })
+    # number of scored (not all-NA) loci; a scalar, matching the main path in
+    # gl.report.heterozygosity. Previously apply(df, 1, ...) returned a
+    # per-individual vector, which recycled against the per-locus Ho.loc/He.loc.
+    n_loc <- sum(colSums(!is.na(df)) > 0)
     Ho.adj.loc <- Ho.loc * n_loc / (n_loc + n.invariant)
     q_freq <- colMeans(df, na.rm = TRUE) / 2
     p_freq <- 1 - q_freq


### PR DESCRIPTION
## Summary
- `pop.het` (in `utils.het.report.r`) computed `n_loc` with `apply(df, 1, ...)`, a per-**individual** count, then multiplied the per-**locus** `Ho.loc`/`He.loc` by it. The adjusted-Ho/He terms recycled (`nLoc` vs `nInd`), so they emitted ~1200 "longer object length is not a multiple of shorter" warnings and, more importantly, computed wrong values.
- **Impact:** `gl.report.heterozygosity` run with `n.invariant > 0` and `nboots > 0` returned corrupted adjusted (autosomal, Schmidt et al. 2021) heterozygosity bootstrap CIs. `gl.test.heterozygosity` discards the term (`aHet = FALSE`), so only the warning leaked there.
- **Fix:** `n_loc <- sum(colSums(!is.na(df)) > 0)` — the scalar count of scored (not all-NA) loci, matching the main non-bootstrap path in `gl.report.heterozygosity`. Also removed the now-redundant warning muffle in `gl.test.heterozygosity`.

## Test plan
- [x] `pop.het(aHet = TRUE)` adjusted means now equal `gl.report.heterozygosity`'s non-bootstrap `Ho.adj`/`He.adj` (matched to 6 dp on `platypus.gl`, all 3 populations).
- [x] `gl.report.heterozygosity(n.invariant = 100, nboots = 100, error.bar = "CI")` runs with zero recycling warnings.
- [x] `gl.test.heterozygosity` runs with zero recycling warnings after dropping the muffle.
